### PR TITLE
Akismet marks my spam as trash; ensure we don't auto-reply trash

### DIFF
--- a/includes/class-jetpack-contact-form-auto-reply.php
+++ b/includes/class-jetpack-contact-form-auto-reply.php
@@ -91,7 +91,7 @@ class Jetpack_Contact_Form_Auto_Reply {
 		// Don't send if email is marked as spam if option is set
 		$not_spam = get_option( $this->settings->base . 'not_spam', '' );
 		$post_status = get_post_status( $post_id );
-		if( $not_spam && 'spam' == $post_status ) {
+		if( $not_spam && ( 'spam' == $post_status || 'trash' == $post_status ) ) {
 			return;
 		}
 


### PR DESCRIPTION
After enabling Akismet (instead of my previous hardcoded "contains_cyrillic" spam filter) I suddenly got quota-blocked with thousands of debug events per day since Akismet seems to mark my spam as 'trash'. This patch ensures 'trash' is also not replied to if not sending 'spam'